### PR TITLE
S3本番環境の設定

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,6 +5,6 @@ test:
   adapter: test
 
 production:
-  adapter: redis
+  adapter: async
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: share_training_app_production

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
@@ -59,4 +59,8 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  ActionCable.server.config.disable_request_forgery_protection = true
+  config.action_cable.url = "ws://54.92.57.45/cable"
+  config.action_cable.allowed_request_origin = ['http://54.92.57.45']
 end


### PR DESCRIPTION
# what
S3本番環境の設定

# why
本番環境でアクティブストレージとコメント機能を使えるようにするため。